### PR TITLE
Added missing API key policy plugin to registry.json

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -8,6 +8,13 @@
     "url" : "https://repo1.maven.org/maven2/"
   },
   "plugins" : [
+     {
+      "groupId" : "io.apiman.plugins",
+      "artifactId" : "apiman-plugins-apikey-policy",
+      "version" : "1.5.6-SNAPSHOT",
+      "name" : "API Key Policy Plugin",
+      "description" : "This plugin provides a policy that can help pass the API Key through to the back-end service."
+    },
     {
       "groupId" : "io.apiman.plugins",
       "artifactId" : "apiman-plugins-cors-policy",


### PR DESCRIPTION
This plugin was installed by default, but if i remove them through manager-ui , it cannot be installed using registry forcing the user to install manually (if knows how)